### PR TITLE
Replace IRIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ This script uses [YouTube's iframe API](https://developers.google.com/youtube/if
 These statements can be dispatched to an LRS with xapiwrapper.min.js using a custom ADL.XAPIYoutubeStatements.onStateChangeCallback function.
 
 Check out http://adlnet.github.io/xapi-youtube for a live demo.
+
+Note that this is a proof of concept prototype to show functionality and **not intended as a guide for the semantics of the statement structure**.

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
     // "global" variables read by ADL.XAPITrackYoutube
     var actor = ADL.XAPIWrapper.lrs['actor'];
-    var videoActivity = {"id":"https://www.youtube.com/watch?v=" + video, "definition":{"name": {"en-US":video}}};
+    var videoActivity = {"id":"https://www.youtube.com/watch?v=" + video, "definition":{"name": {"en-US":video}, "type": "http://activitystrea.ms/schema/1.0/video"}};
 
     function initYT() {
       var tag = document.createElement('script');

--- a/src/xapi-youtube-statements.js
+++ b/src/xapi-youtube-statements.js
@@ -56,8 +56,8 @@
           default:
         }
         playerPreviousState = event.data;
-        playerPreviousTime = ISOTime;
         ADL.XAPIYoutubeStatements.onStateChangeCallback(e, stmt);
+        playerPreviousTime = ISOTime;
       };
 
       function playVideo(ISOTime) {

--- a/src/xapi-youtube-statements.js
+++ b/src/xapi-youtube-statements.js
@@ -55,14 +55,16 @@
             break;
           default:
         }
+        playerPreviousState = event.data;
+        playerPreviousTime = ISOTime;
         ADL.XAPIYoutubeStatements.onStateChangeCallback(e, stmt);
       };
 
       function playVideo(ISOTime) {
             var stmt = {
                 "actor": actor,
-                "object": videoActivity,
                 "verb": { "id": "http://activitystrea.ms/schema/1.0/play", "display": { "en-US": "played" } },
+                "object": videoActivity,
                 "context": {
                     "contextActivities": {"category": {"id":"http://id.tincanapi.com/recipe/video/base/1"}},
                     "extensions": { "http://id.tincanapi.com/extension/starting-point": ISOTime }
@@ -71,16 +73,31 @@
             return stmt;
         }
 
-      function pauseVideo(ISOTime) {
+       function pauseVideo(ISOTime) {
             var stmt = {
                 "actor": actor,
-                "verb": { "id": "http://id.tincanapi.com/verb/paused", "display": { "en-US": "paused" } },
+                "verb": " ",
                 "object": videoActivity,
                 "context": {
-                    "contextActivities": { "category": { "id": "http://id.tincanapi.com/recipe/video/base/1" } },
-                    "extensions": { "http://id.tincanapi.com/extension/ending-point": ISOTime }
+                    "contextActivities": {
+                        "category": { "id": "http://id.tincanapi.com/recipe/video/base/1" }
+                    },
+                    "extensions": " "
                 }
             };
+            
+            if (playerPreviousState == 2 || playerPreviousState == 5) {
+                stmt.verb = { "id": "http://id.tincanapi.com/verb/skipped", "display": { "en-US": "skipped" } };
+                stmt.context.extensions = {
+                    "http://id.tincanapi.com/extension/starting-point": playerPreviousTime,
+                    "http://id.tincanapi.com/extension/ending-point": ISOTime
+                };
+
+            } else {
+                stmt.verb = { "id": "http://id.tincanapi.com/verb/paused", "display": { "en-US": "paused" } };
+                stmt.context.extensions = { "http://id.tincanapi.com/extension/ending-point": ISOTime };
+            }
+            
             return stmt;
         }
 

--- a/src/xapi-youtube-statements.js
+++ b/src/xapi-youtube-statements.js
@@ -62,7 +62,7 @@
             var stmt = {
                 "actor": actor,
                 "object": videoActivity,
-                "verb": { "id": "http://activitystrea.ms/schema/1.0/play", "display": { "en-US": "play" } },
+                "verb": { "id": "http://activitystrea.ms/schema/1.0/play", "display": { "en-US": "played" } },
                 "context": {
                     "contextActivities": {"category": {"id":"http://id.tincanapi.com/recipe/video/base/1"}},
                     "extensions": { "http://id.tincanapi.com/extension/starting-point": ISOTime }

--- a/src/xapi-youtube-statements.js
+++ b/src/xapi-youtube-statements.js
@@ -13,13 +13,12 @@
     } 
 
     XAPIYoutubeStatements = function() {
-
       this.onPlayerReady = function(event) {
         //event.target.playVideo();
         var message = "yt: player ready";
         log(message);
         ADL.XAPIYoutubeStatements.onPlayerReadyCallback(message);
-      }
+      };
 
       this.onStateChange = function(event) {
         var curTime = player.getCurrentTime().toString();
@@ -57,45 +56,48 @@
           default:
         }
         ADL.XAPIYoutubeStatements.onStateChangeCallback(e, stmt);
-      }
+      };
 
       function playVideo(ISOTime) {
-        var stmt = {"actor":actor, "object": videoActivity};
-        /*if (competency) {
-          stmt["context"] = {"contextActivities":{"other" : [{"id": "compID:" + competency}]}};
-        }*/
-
-        stmt["verb"] = {"id": "http://activitystrea.ms/schema/1.0/play"};
-        stmt["result"] = {"extensions":{"http://id.tincanapi.com/extension/starting-point":ISOTime}};
-        return stmt;
-      }
+            var stmt = {
+                "actor": actor,
+                "object": videoActivity,
+                "verb": { "id": "http://activitystrea.ms/schema/1.0/play", "display": { "en-US": "play" } },
+                "context": {
+                    "contextActivities": {"category": {"id":"http://id.tincanapi.com/recipe/video/base/1"}},
+                    "extensions": { "http://id.tincanapi.com/extension/starting-point": ISOTime }
+                }
+            };
+            return stmt;
+        }
 
       function pauseVideo(ISOTime) {
-          var stmt = {"actor":actor, 
-                  "verb": "http://id.tincanapi.com/verb/paused",
-                  "object":videoActivity, 
-                  "result":{"extensions":{"http://id.tincanapi.com/extension/ending-point":ISOTime}}};
-
-          /*if (competency) {
-              stmt["context"] = {"contextActivities":{"other" : [{"id": "compID:" + competency}]}};
-          }*/
-          return stmt;
-      }
+            var stmt = {
+                "actor": actor,
+                "verb": { "id": "http://id.tincanapi.com/verb/paused", "display": { "en-US": "paused" } },
+                "object": videoActivity,
+                "context": {
+                    "contextActivities": { "category": { "id": "http://id.tincanapi.com/recipe/video/base/1" } },
+                    "extensions": { "http://id.tincanapi.com/extension/ending-point": ISOTime }
+                }
+            };
+            return stmt;
+        }
 
       function completeVideo(ISOTime) {
-          var stmt = {"actor":actor, 
-                  "verb":"http://activitystrea.ms/schema/1.0/complete", 
-                  "object":videoActivity, 
-                  "result":{"completion": true},
-                  "context":{"extensions":["http://id.tincanapi.com/extension/ending-point": ISOTime]}};
-
-          /*if (competency) {
-              stmt["context"] = {"contextActivities":{"other" : [{"id": "compID:" + competency}]}};
-          }*/
-          return stmt;
-      }
-
-    }
+            var stmt = {
+                "actor": actor,
+                "verb": { "id": "http://activitystrea.ms/schema/1.0/complete", "display": {"en-US": "completed"} },
+                "object": videoActivity,
+                "result": {"duration":ISOTime, "completion": true},
+                "context": {
+                    "contextActivities": { "category": { "id": "http://id.tincanapi.com/recipe/video/base/1" } },
+                    "extensions": { "http://id.tincanapi.com/extension/ending-point": ISOTime }
+                }
+            };
+            return stmt;
+        }
+    };
 
     ADL.XAPIYoutubeStatements = new XAPIYoutubeStatements();
 

--- a/src/xapi-youtube-statements.js
+++ b/src/xapi-youtube-statements.js
@@ -65,20 +65,16 @@
           stmt["context"] = {"contextActivities":{"other" : [{"id": "compID:" + competency}]}};
         }*/
 
-        if (ISOTime == "PT0S") {
-          stmt["verb"] = ADL.verbs.launched;
-        } else {
-          stmt["verb"] = ADL.verbs.resumed;
-          stmt["result"] = {"extensions":{"resultExt:resumed":ISOTime}};
-        }
+        stmt["verb"] = {"id": "http://activitystrea.ms/schema/1.0/play"};
+        stmt["result"] = {"extensions":{"http://id.tincanapi.com/extension/starting-point":ISOTime}};
         return stmt;
       }
 
       function pauseVideo(ISOTime) {
           var stmt = {"actor":actor, 
-                  "verb":ADL.verbs.suspended,
+                  "verb": "http://id.tincanapi.com/verb/paused",
                   "object":videoActivity, 
-                  "result":{"extensions":{"resultExt:paused":ISOTime}}};
+                  "result":{"extensions":{"http://id.tincanapi.com/extension/ending-point":ISOTime}}};
 
           /*if (competency) {
               stmt["context"] = {"contextActivities":{"other" : [{"id": "compID:" + competency}]}};
@@ -88,9 +84,10 @@
 
       function completeVideo(ISOTime) {
           var stmt = {"actor":actor, 
-                  "verb":ADL.verbs.completed, 
+                  "verb":"http://activitystrea.ms/schema/1.0/complete", 
                   "object":videoActivity, 
-                  "result":{"duration":ISOTime, "completion": true}};
+                  "result":{"completion": true},
+                  "context":{"extensions":["http://id.tincanapi.com/extension/ending-point": ISOTime]}};
 
           /*if (competency) {
               stmt["context"] = {"contextActivities":{"other" : [{"id": "compID:" + competency}]}};


### PR DESCRIPTION
As this is in the public ADL github and listed in the CoP Google Group, there's a reasonable chance somebody could look at this as a guide for the semantics of statement structure, which I understand is not the intention of this project. Instead people should look to existing implementations as documented in the [Registry](https://registry.tincanapi.com/#profile/19) and the work of the [Video CoP](http://www.adlnet.gov/tla/experience-api/xapi-cop-directory/xapi-cop-directory-list-view/entry/videos/). 

This PR adds to the readme to make clear that this is not a statement structure guide and replaces a number of the IRIs used. 

Note that this PR does not make this project fully conformant to the Registry recipe, as not all data and events are represented. 
